### PR TITLE
Framework Dependant Publishing (Cross Platform)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,11 +7,10 @@ APP_DIR=$START_DIR/built/app
 rm -rf $START_DIR/bin
 rm -rf $APP_DIR
 
-dotnet build --configuration Release
+dotnet publish --configuration Release --self-contained false
 
 mkdir -p built/app
 
-mv $BINARIES_DIR/dbc-export.exe $APP_DIR
 mv $BINARIES_DIR/dbc-export.dll $APP_DIR
 mv $BINARIES_DIR/dbc-export.runtimeconfig.json $APP_DIR
 mv $BINARIES_DIR/Microsoft.Extensions.* $APP_DIR


### PR DESCRIPTION
Updated the build script to generate a framework dependant binary. This means we don't get an exe on windows or an explicit linux binary instead it's built against .net 5.0 and users must install the redistributable. I'll make sure to update docs to make this obvious too. 

Just execute with `dotnet dbc-export.dll`. 