### PR TITLE
Area Trigger Fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "program": "${workspaceFolder}/bin/Debug/net5.0/dbc-export.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
-            "console": "internalConsole",
+            "console": "externalTerminal",
             "stopAtEntry": false
         },
         {

--- a/DBC/Builder.cs
+++ b/DBC/Builder.cs
@@ -139,7 +139,14 @@ namespace dbc_export
 
             fields = fields.Substring(0, fields.Length - 2); // Hacky. Removes the final comma and space.
 
-            MySqlCommand query = new MySqlCommand(String.Format("SELECT {0} FROM {1}", fields, definition.Table), connection);
+            string command = String.Format("SELECT {0} FROM {1}", fields, definition.Table);
+
+            if (definition.OrderBy != "none")
+            {
+                command = String.Format("{0} ORDER BY {1} {2}", command, definition.OrderBy, definition.OrderDirection.ToUpper());
+            }
+
+            MySqlCommand query = new MySqlCommand(command, connection);
 
             MySqlDataReader result = query.ExecuteReader();
 

--- a/DBC/Builder.cs
+++ b/DBC/Builder.cs
@@ -141,9 +141,9 @@ namespace dbc_export
 
             string command = String.Format("SELECT {0} FROM {1}", fields, definition.Table);
 
-            if (definition.OrderBy != "none")
+            if (definition.Ordering != "none")
             {
-                command = String.Format("{0} ORDER BY {1} {2}", command, definition.OrderBy, definition.OrderDirection.ToUpper());
+                command = String.Format("{0} ORDER BY {1} {2}", command, definition.Ordering, definition.Direction.ToUpper());
             }
 
             MySqlCommand query = new MySqlCommand(command, connection);

--- a/DBC/Definition.cs
+++ b/DBC/Definition.cs
@@ -29,12 +29,12 @@ namespace dbc_export
         /// The column we should order by when querying
         /// </summary>
         /// <value></value>
-        public string OrderBy { get; set; } = "none";
+        public string Ordering { get; set; } = "none";
 
         /// <summary>
         /// The direction to sort the above column.
         /// </summary>
         /// <value></value>
-        public string OrderDirection { get; set; } = "none";
+        public string Direction { get; set; } = "none";
     }
 }

--- a/DBC/Definition.cs
+++ b/DBC/Definition.cs
@@ -24,5 +24,17 @@ namespace dbc_export
         /// </summary>
         /// <value></value>
         public List<Field> Fields { get; set; }
+
+        /// <summary>
+        /// The column we should order by when querying
+        /// </summary>
+        /// <value></value>
+        public string OrderBy { get; set; } = "none";
+
+        /// <summary>
+        /// The direction to sort the above column.
+        /// </summary>
+        /// <value></value>
+        public string OrderDirection { get; set; } = "none";
     }
 }

--- a/definitions.json
+++ b/definitions.json
@@ -75,6 +75,22 @@
             ]
         },
         {
+            "name": "AreaTrigger",
+            "table": "areatrigger",
+            "fields": [
+                {"name": "entry", "type": "int"},
+                {"name": "map", "type": "int"},
+                {"name": "x", "type": "float"},
+                {"name": "y", "type": "float"},
+                {"name": "z", "type": "float"},
+                {"name": "radius", "type": "float"},
+                {"name": "length", "type": "float"},
+                {"name": "width", "type": "float"},
+                {"name": "height", "type": "float"},
+                {"name": "orientation", "type": "float"}
+            ]
+        },
+        {
             "name": "BattlemasterList",
             "table": "battlemasterlist_dbc",
             "fields": [

--- a/definitions.json
+++ b/definitions.json
@@ -77,8 +77,8 @@
         {
             "name": "AreaTrigger",
             "table": "areatrigger",
-            "order_by": "map",
-            "order_direction": "ASC", 
+            "ordering": "map",
+            "direction": "ASC", 
             "fields": [
                 {"name": "entry", "type": "int"},
                 {"name": "map", "type": "int"},

--- a/definitions.json
+++ b/definitions.json
@@ -77,6 +77,8 @@
         {
             "name": "AreaTrigger",
             "table": "areatrigger",
+            "order_by": "map",
+            "order_direction": "ASC", 
             "fields": [
                 {"name": "entry", "type": "int"},
                 {"name": "map", "type": "int"},


### PR DESCRIPTION
Apparently area triggers are a weird case. They should be exported sorting by map id ascending otherwise new ones do not seem to trigger correctly. Maybe the client is doing some extra checks?

Either way by explicitly ordering by that field and exporting I have managed to produce a working area trigger.